### PR TITLE
#121 show and honor node allocatable

### DIFF
--- a/app/src/bars.js
+++ b/app/src/bars.js
@@ -24,20 +24,24 @@ export default class Bars extends PIXI.Graphics {
         const cpuHeight = barHeight / bars.resources.cpu.capacity
         bars.interactive = true
         bars.lineStyle(0, 0xaaffaa, 1)
-        bars.beginFill(getBarColor(bars.resources.cpu.requested, bars.resources.cpu.capacity), 1)
-        bars.drawRect(5, 110 - bars.resources.cpu.requested * cpuHeight, 2.5, bars.resources.cpu.requested * cpuHeight)
+        bars.beginFill(getBarColor(bars.resources.cpu.requested, bars.resources.cpu.capacity - bars.resources.cpu.reserved), 1)
+        bars.drawRect(5, 110 - (bars.resources.cpu.requested + bars.resources.cpu.reserved) * cpuHeight, 2.5, (bars.resources.cpu.requested + bars.resources.cpu.reserved) * cpuHeight)
         bars.beginFill(getBarColor(bars.resources.cpu.used, bars.resources.cpu.capacity), 1)
         bars.drawRect(7.5, 110 - bars.resources.cpu.used * cpuHeight, 2.5, bars.resources.cpu.used * cpuHeight)
         bars.endFill()
+        bars.lineStyle(1, App.current.theme.primaryColor, 1)
+        bars.drawRect(5, 110 - bars.resources.cpu.reserved * cpuHeight, 5, bars.resources.cpu.reserved * cpuHeight)
 
         // Memory
         const scale = bars.resources.memory.capacity / barHeight
         bars.lineStyle(0, 0xaaffaa, 1)
-        bars.beginFill(getBarColor(bars.resources.memory.requested, bars.resources.memory.capacity), 1)
-        bars.drawRect(14, 110 - bars.resources.memory.requested / scale, 2.5, bars.resources.memory.requested / scale)
+        bars.beginFill(getBarColor(bars.resources.memory.requested, bars.resources.memory.capacity - bars.resources.memory.reserved), 1)
+        bars.drawRect(14, 110 - (bars.resources.memory.requested + bars.resources.memory.reserved) / scale, 2.5, (bars.resources.memory.requested + bars.resources.memory.reserved) / scale)
         bars.beginFill(getBarColor(bars.resources.memory.used, bars.resources.memory.capacity), 1)
         bars.drawRect(16.5, 110 - bars.resources.memory.used / scale, 2.5, bars.resources.memory.used / scale)
         bars.endFill()
+        bars.lineStyle(1, App.current.theme.primaryColor, 1)
+        bars.drawRect(14, 110 - bars.resources.memory.reserved / scale, 5, bars.resources.memory.reserved / scale)
 
         bars.lineStyle(1, App.current.theme.primaryColor, 1)
         for (var i = 0; i < bars.resources.cpu.capacity; i++) {
@@ -48,14 +52,16 @@ export default class Bars extends PIXI.Graphics {
 
         bars.on('mouseover', function () {
             let s = 'CPU: \n'
-            const {capacity: cpuCap, requested: cpuReq, used: cpuUsed} = bars.resources.cpu
+            const {capacity: cpuCap, reserved: cpuRes, requested: cpuReq, used: cpuUsed} = bars.resources.cpu
             s += '\t\t Capacity  : ' + cpuCap + '\n'
+            s += '\t\t Reserved  : ' + cpuRes.toFixed(2) + '\n'
             s += '\t\t Requested : ' + cpuReq.toFixed(2) + '\n'
             s += '\t\t Used      : ' + cpuUsed.toFixed(2) + '\n'
             s += '\nMemory: \n'
 
-            const {capacity: memCap, requested: memReq, used: memUsed} = bars.resources.memory
+            const {capacity: memCap, reserved: memRes, requested: memReq, used: memUsed} = bars.resources.memory
             s += '\t\t Capacity  : ' + (memCap / FACTORS.Gi).toFixed(2) + ' GiB\n'
+            s += '\t\t Reserved  : ' + (memRes / FACTORS.Gi).toFixed(2) + ' GiB\n'
             s += '\t\t Requested : ' + (memReq / FACTORS.Gi).toFixed(2) + ' GiB\n'
             s += '\t\t Used      : ' + (memUsed / FACTORS.Gi).toFixed(2) + ' GiB\n'
 

--- a/app/src/node.js
+++ b/app/src/node.js
@@ -21,8 +21,13 @@ export default class Node extends PIXI.Graphics {
         for (const key of Object.keys(this.node.status.capacity)) {
             resources[key] = {
                 'capacity': parseResource(this.node.status.capacity[key]),
+                'reserved': 0,
                 'requested': 0,
                 'used': 0
+            }
+            const allocatable = this.node.status.allocatable[key]
+            if (allocatable) {
+                resources[key]['reserved'] = resources[key]['capacity'] - parseResource(allocatable)
             }
         }
         if (this.node.usage) {

--- a/kube_ops_view/kubernetes.py
+++ b/kube_ops_view/kubernetes.py
@@ -16,6 +16,7 @@ def map_node_status(status: dict):
     return {
         'addresses': status.get('addresses'),
         'capacity': status.get('capacity'),
+        'allocatable': status.get('allocatable')
     }
 
 

--- a/kube_ops_view/mock.py
+++ b/kube_ops_view/mock.py
@@ -67,7 +67,9 @@ def query_mock_cluster(cluster):
             else:
                 pod = generate_mock_pod(index, i, j)
                 pods['{}/{}'.format(pod['namespace'], pod['name'])] = pod
-        node = {'name': 'node-{}'.format(i), 'labels': labels, 'status': {'capacity': {'cpu': '4', 'memory': '32Gi', 'pods': '110'}}, 'pods': pods}
+        node = {'name': 'node-{}'.format(i), 'labels': labels, 'status': {
+            'capacity': {'cpu': '4', 'memory': '32Gi', 'pods': '110'},
+            'allocatable': {'cpu': '3800m', 'memory': '31Gi'}}, 'pods': pods}
         nodes[node['name']] = node
     pod = generate_mock_pod(index, 11, index)
     unassigned_pods = {'{}/{}'.format(pod['namespace'], pod['name']): pod}


### PR DESCRIPTION
Show reserved resources in the UI (for system, Docker, kubelet). 
Fixes #121.

The amount of reserved CPU/memory resources is marked with a line at the bottom of the resource bars. The height of the color bar itself is now `requested` + `reserved` (total bar box has still the height of the total node capacity!).
![screenshot_2017-02-12_14-12-20](https://cloud.githubusercontent.com/assets/510328/22862387/c85e3bc8-f12d-11e6-94df-9e255023d2cf.png)


