### PR TITLE
Add RBAC configuration

### DIFF
--- a/deploy/auth.yaml
+++ b/deploy/auth.yaml
@@ -13,7 +13,7 @@ rules:
   resources: ["nodes", "pods"]
   verbs:
     - list
-- apiGroups: ["*"]
+- apiGroups: [""]
   resources: ["services/proxy"]
   resourceNames: ["heapster"]
   verbs:

--- a/deploy/auth.yaml
+++ b/deploy/auth.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ops-view
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-ops-view
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs:
+    - list
+- apiGroups: ["*"]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster"]
+  verbs:
+    - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-ops-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-ops-view
+subjects:
+- kind: ServiceAccount
+  name: kube-ops-view
+  namespace: default

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         application: kube-ops-view
         version: v0.0.1
     spec:
+      serviceAccount: kube-ops-view
       containers:
       - name: service
         image: hjacobs/kube-ops-view:latest


### PR DESCRIPTION
Fixes #134 

Add service account with specific configuration for kube-ops-view to work. Useful for Kubernetes 1.6.x since it has RBAC enabled by default in clusters set up with `kubeadm`.