### PR TITLE
Add VERIFY_CERT to allow cert verification to be turned off

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,8 @@ The following environment variables are supported:
     Optional Redis server to use for pub/sub events and job locking when running more than one replica. Example: ``redis://my-redis:6379``
 ``SERVER_PORT``
     HTTP port to listen on. It defaults to ``8080``.
+``VERIFY_CERT``
+    Set to "false" to turn off cert verification of Kubernetes API server (e.g. when using a token secret without a CA).
 
 
 Supported Browsers

--- a/kube_ops_view/kubernetes.py
+++ b/kube_ops_view/kubernetes.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import time
 from urllib.parse import urljoin
 
@@ -54,7 +55,12 @@ def request(cluster, path, **kwargs):
         kwargs['timeout'] = (5, 15)
     if cluster.cert_file and cluster.key_file:
         kwargs['cert'] = (cluster.cert_file, cluster.key_file)
-    return session.get(urljoin(cluster.api_server_url, path), auth=cluster.auth, verify=cluster.ssl_ca_cert, **kwargs)
+    VERIFY_CERT = os.getenv('VERIFY_CERT', '')
+    if VERIFY_CERT == "false":
+        verify = False
+    else:
+        verify = cluster.ssl_ca_cert
+    return session.get(urljoin(cluster.api_server_url, path), auth=cluster.auth, verify=verify, **kwargs)
 
 
 def parse_time(s: str):


### PR DESCRIPTION
First of all, thanks for the awesome app. This made my life much easier this week, managing 5 clusters.  To simplify testing and early deployment, I'd like to be able to disable cert verification against the master.  Clearly not something we'd want to suggest everyone do but it's much easier for me to generate a service account token and point it at a cluster, then passing around a CA as well.

I was debating between:
``` python
VERIFY_CERT=os.getenv('VERIFY_CERT','')
or
verify=os.getenv('SKIP_CERT_VERIFICATION',cluster.ssl_ca_cert)
```
So if you have a preference, let me know!