### PR TITLE
Respect new node role label to detect master nodes (#149)

### DIFF
--- a/app/src/node.js
+++ b/app/src/node.js
@@ -13,7 +13,13 @@ export default class Node extends PIXI.Graphics {
     }
 
     isMaster() {
-        return this.node.labels.master == 'true'
+        for (var key in this.node.labels) {
+            if (key == 'node-role.kubernetes.io/master' ||
+                key == 'kubernetes.io/role' && this.node.labels[key] == 'master' ||
+                key == 'master' && this.node.labels[key] == 'true' ) {
+                return true
+            }
+        }
     }
 
     getResourceUsage() {

--- a/kube_ops_view/mock.py
+++ b/kube_ops_view/mock.py
@@ -69,7 +69,12 @@ def query_mock_cluster(cluster):
             continue
         labels = {}
         if i < 2:
-            labels['master'] = 'true'
+            if index == 0:
+                labels['kubernetes.io/role'] = 'master'
+            elif index == 1:
+                labels['node-role.kubernetes.io/master'] = ''
+            else:
+                labels['master'] = 'true'
         pods = {}
         for j in range(hash_int((index + 1) * (i + 1)) % 32):
             # add/remove some pods every 7 seconds


### PR DESCRIPTION
This solves #149

For `node-role.kubernetes.io/master` I'm not checking label vaule, similar to the way it is done here: https://github.com/kubernetes/kubernetes/blob/v1.8.0/pkg/printers/internalversion/printers.go#L1203-L1221 