### PR TITLE
Respect new node role label to detect LB nodes (#149)

### DIFF
--- a/app/src/cluster.js
+++ b/app/src/cluster.js
@@ -33,6 +33,10 @@ export default class Cluster extends PIXI.Graphics {
         let masterY = top
         let masterWidth = 0
         let masterHeight = 0
+        let lbX = left
+        let lbY = top
+        let lbWidth = 0
+        let lbHeight = 0
         let workerX = left
         let workerY = top
         let workerWidth = 0
@@ -56,6 +60,19 @@ export default class Cluster extends PIXI.Graphics {
                 nodeBox.x = masterX
                 nodeBox.y = masterY
                 masterX += nodeBox.width + padding
+            } else if (nodeBox.isLB()) {
+                if (lbX > maxWidth) {
+                    lbWidth = lbX
+                    lbX = masterX + 105 + padding
+                    lbY += nodeBox.height + padding
+                    lbHeight += masterHeight + nodeBox.height + padding
+                }
+                if (lbHeight == 0) {
+                    lbHeight = masterHeight + nodeBox.height + padding
+                }
+                nodeBox.x = lbX
+                nodeBox.y = lbY + masterHeight
+                lbX += nodeBox.width + padding
             } else {
                 if (workerX > maxWidth) {
                     workerWidth = workerX
@@ -74,7 +91,7 @@ export default class Cluster extends PIXI.Graphics {
             this.addChild(nodeBox)
         }
         for (const nodeBox of workerNodes) {
-            nodeBox.y += masterHeight
+            nodeBox.y += lbHeight ? lbHeight : masterHeight
         }
 
 
@@ -90,8 +107,8 @@ export default class Cluster extends PIXI.Graphics {
         workerWidth = Math.max(workerX, workerWidth)
 
         this.lineStyle(2, App.current.theme.primaryColor, 1)
-        const width = Math.max(masterWidth, workerWidth)
-        this.drawRect(0, 0, width, top + masterHeight + workerHeight)
+        const width = Math.max(masterWidth, lbWidth, workerWidth)
+        this.drawRect(0, 0, width, top + (lbHeight ? lbHeight : masterHeight) + workerHeight)
 
         const topHandle = this.topHandle = new PIXI.Graphics()
         topHandle.beginFill(App.current.theme.primaryColor, 1)

--- a/app/src/node.js
+++ b/app/src/node.js
@@ -22,6 +22,16 @@ export default class Node extends PIXI.Graphics {
         }
     }
 
+    isLB() {
+        for (var key in this.node.labels) {
+            if (key == 'node-role.kubernetes.io/lb' ||
+                key == 'kubernetes.io/role' && this.node.labels[key] == 'lb' ||
+                key == 'lb' && this.node.labels[key] == 'true' ) {
+                return true
+            }
+        }
+    }
+
     getResourceUsage() {
         const resources = {}
         for (const key of Object.keys(this.node.status.capacity)) {

--- a/kube_ops_view/cluster_discovery.py
+++ b/kube_ops_view/cluster_discovery.py
@@ -161,5 +161,5 @@ class KubeconfigDiscoverer:
 class MockDiscoverer:
 
     def get_clusters(self):
-        for i in range(3):
+        for i in range(4):
             yield Cluster('mock-cluster-{}'.format(i), api_server_url='https://kube-{}.example.org'.format(i))

--- a/kube_ops_view/mock.py
+++ b/kube_ops_view/mock.py
@@ -75,6 +75,14 @@ def query_mock_cluster(cluster):
                 labels['node-role.kubernetes.io/master'] = ''
             else:
                 labels['master'] = 'true'
+        if i >= 2 and i < 4:
+            if index == 0:
+                labels['kubernetes.io/role'] = 'lb'
+            elif index == 1:
+                labels['node-role.kubernetes.io/lb'] = ''
+            elif index == 2:
+                labels['lb'] = 'true'
+            # no lb label for last cluster, as lb can be provided externally
         pods = {}
         for j in range(hash_int((index + 1) * (i + 1)) % 32):
             # add/remove some pods every 7 seconds


### PR DESCRIPTION


This solves #149
Nodes with "LB" role, if they are in cluster, will be displayed in second row. 
![b888b869-0347-4819-9dbd-5f9a2bb1a4dd](https://user-images.githubusercontent.com/10206601/35122201-3bfcb1b4-fc9e-11e7-83bb-db2bc6e74d39.jpg)
