### PR TITLE
Handle Pods were memory.request > memory.limit

### DIFF
--- a/app/src/pod.js
+++ b/app/src/pod.js
@@ -281,7 +281,7 @@ export class Pod extends PIXI.Graphics {
         podBox.endFill()
 
         // Memory
-        const scale = resources.memory.limit / 8
+        const scale = resources.memory.requested <= resources.memory.limit ? resources.memory.limit / 8 : resources.memory.requested / 8
         const scaledMemReq = resources.memory.requested !== 0 && scale !== 0 ? resources.memory.requested / scale : 0
         const scaledMemUsed = resources.memory.used !== 0 && scale !== 0 ? resources.memory.used / scale : 0
         podBox.lineStyle()


### PR DESCRIPTION
If a pod contains multiple containers the total memory limit can be smaller then the total request:

Container A: Request 200Mi / No limit set
Container B: Request 10Mi / Limit 10Mi

This results in rendering Request 210Mi, Limit 10Mi and the bar showing the relation from Request and limit growing way out of bounds. This PR fixes that issue by applying the larger of the two values for scaling. Even though this does not correctly show the relation anymore, this is acceptable in my opinion in this rare edge case.