### PR TITLE
Tooltip fix

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -365,7 +365,7 @@ export default class App {
             this.drawMenuBar()
         }
 
-        const tooltip = new Tooltip()
+        const tooltip = this.tooltip || new Tooltip()
         tooltip.draw()
         this.stage.addChild(tooltip)
 


### PR DESCRIPTION
When switching themes the app `draw()` method is called, which creates a new Tooltip. This means the existing tooltips used by exiting pods no longer work. You can replicate this by changing the theme and trying to get the pod tooltips to display - the tooltips are no longer available.

This PR leaves the existing tooltip object, meaning changes to the theme no longer break the pod tooltips.