### PR TITLE
Windows build fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/app/README.rst
+++ b/app/README.rst
@@ -12,3 +12,16 @@ Frontend development is supported by watching the source code and continuously r
 .. code-block:: bash
 
     $ npm start
+
+Windows uses slightly different scripts. This will build the JavaScript app in Windows:
+
+.. code-block:: powershell
+
+    $ npm install
+    $ npm run buildwin
+
+This will start the code watch and rebuild script in Windows:
+
+.. code-block:: powershell
+
+    $ npm run startwin

--- a/app/package.json
+++ b/app/package.json
@@ -8,9 +8,11 @@
   },
   "scripts": {
     "prestart": "npm install",
-    "start": "NODE_ENV=development webpack --watch",
+    "start": "NODE_ENV=development webpack --watch --info-verbosity verbose",
+    "startwin": "SET NODE_ENV=development & webpack --watch --info-verbosity verbose",
     "webpack": "webpack -p --config ./webpack.config.js",
     "build": "NODE_ENV=production npm run webpack",
+    "buildwin": "SET NODE_ENV=production & npm run webpack",
     "prewebpack": "npm run clean",
     "lint": "eslint ./src/**/*.js",
     "clean": "rimraf $npm_package_config_buildDir && mkdir $npm_package_config_buildDir"

--- a/app/package.json
+++ b/app/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "prestart": "npm install",
-    "start": "NODE_ENV=development webpack --watch --info-verbosity verbose",
-    "startwin": "SET NODE_ENV=development & webpack --watch --info-verbosity verbose",
+    "start": "NODE_ENV=development webpack --watch",
+    "startwin": "SET NODE_ENV=development & webpack --watch",
     "webpack": "webpack -p --config ./webpack.config.js",
     "build": "NODE_ENV=production npm run webpack",
     "buildwin": "SET NODE_ENV=production & npm run webpack",


### PR DESCRIPTION
When building the app in Windows the files need to have the LF line endings (instead of the default CRLF) to satisfy the linter. Some scripts also need to be changed to work in Windows consoles. This PR has a `.gitattributes` file that sets the correct line endings and adds some windows NPM build scripts.