### PR TITLE
Add filter for namespace #160

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -74,11 +74,22 @@ export default class App {
         return labels && labels[name] === value
     }
 
+    namespaceMatches(pod, value) {
+        return pod.namespace === value
+    }
+
     createMatchesFunctionForQuery(query) {
-        if (query.includes('=')) {
-            const labelAndValue = query.split('=', 2)
-            return pod => this.labelMatches(pod, labelAndValue[0], labelAndValue[1])
-        } else {
+        if (query.startsWith('namespace=')) {
+            // filter by namespace
+            const value = query.split('namespace=', 2)[1]
+            return pod => this.namespaceMatches(pod, value)
+        } else if (query.includes('=')) {
+            // filter by label
+            const [label, value] = query.split('=', 2)
+            return pod => this.labelMatches(pod, label, value)
+        }
+        else {
+            // filter by name
             return pod => this.nameMatches(pod, query)
         }
     }

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -35,6 +35,7 @@ You can filter by:
 
 * name
 * labels - when query includes ``=``, e.g. ``env=prod``
+* namespace - when query starts with ``namespace``, e.g. ``namespace=default``
 
 The pod filter is persisted in the location bar (``#q=..`` query parameter) which allows to conveniently send the filtered view to other users (e.g. for troubleshooting).
 


### PR DESCRIPTION
Filtering by namespace (identical like filtering by labels).

It is much simpler to implement than a drop-down selector (as @otrosien suggested). So, we might keep it in this form until the drop-down selector is ready.

<img width="342" alt="screenshot 2019-03-08 at 18 43 29" src="https://user-images.githubusercontent.com/1127164/54046987-2620c780-41d6-11e9-862d-8c46b23377d5.png">
<img width="455" alt="screenshot 2019-03-08 at 18 42 33" src="https://user-images.githubusercontent.com/1127164/54046988-2620c780-41d6-11e9-9cb0-dbdc6694b0e7.png">
<img width="457" alt="screenshot 2019-03-08 at 18 42 06" src="https://user-images.githubusercontent.com/1127164/54046989-2620c780-41d6-11e9-91da-75c7f10e01cd.png">