### PR TITLE
Scale masters separately

### DIFF
--- a/app/src/bars.js
+++ b/app/src/bars.js
@@ -14,8 +14,8 @@ export default class Bars extends PIXI.Graphics {
     draw() {
         const bars = this
 
-        const barHeightPx = bars.entity.cluster.heightOfNodePx - (App.current.heightOfTopHandlePx + 5 + 3)
-        const heightOfNodeWoPaddingPx = bars.entity.cluster.heightOfNodePx - 5
+        const barHeightPx = bars.entity.heightOfNodePx - (App.current.heightOfTopHandlePx + 5 + 3)
+        const heightOfNodeWoPaddingPx = bars.entity.heightOfNodePx - 5
 
         bars.beginFill(App.current.theme.primaryColor, 0.1)
         bars.drawRect(5, heightOfNodeWoPaddingPx - barHeightPx, 15, barHeightPx)


### PR DESCRIPTION
Without this, master nodes can fill too much space.

Here is a simple preview:
<img width="1335" alt="Screenshot 2019-03-12 at 18 27 10" src="https://user-images.githubusercontent.com/1127164/54222324-7741fb80-44f5-11e9-9fc0-252efd4a68e1.png">
