### PR TITLE
Fix definition of OAuth2 scope parameter

### DIFF
--- a/kube_ops_view/main.py
+++ b/kube_ops_view/main.py
@@ -42,7 +42,7 @@ oauth_blueprint = OAuth2ConsumerBlueprintWithClientRefresh(
     "oauth", __name__,
     authorization_url=AUTHORIZE_URL,
     token_url=ACCESS_TOKEN_URL,
-    token_url_params={'scope': SCOPE} if SCOPE else None,
+    scope=SCOPE
 )
 app.register_blueprint(oauth_blueprint, url_prefix="/login")
 


### PR DESCRIPTION
Hello,

Flask-dance has separate parameter for scope definition and token_url_params{"scope": SCOPE} does not work anymore(tested with google OAuth2 only) as it being overwriten with scope=None. So, i have modified it to use scope variable "https://flask-dance.readthedocs.io/en/latest/_modules/flask_dance/consumer/oauth2.html". 