### PR TITLE
Refactor code to support running on secure environments

### DIFF
--- a/deploy/auth.yaml
+++ b/deploy/auth.yaml
@@ -1,8 +1,14 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-ops-view
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ops-view-redis
+  namespace: default
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     application: kube-ops-view
     version: v0.11
   name: kube-ops-view
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,13 +17,12 @@ spec:
         application: kube-ops-view
         version: v0.11
     spec:
-      serviceAccount: kube-ops-view
+      serviceAccountName: kube-ops-view
       containers:
       - name: service
         # see https://github.com/hjacobs/kube-ops-view/releases
         image: hjacobs/kube-ops-view:0.11
         args:
-        # remove this option to use built-in memory store
         - --redis-url=redis://kube-ops-view-redis:6379
         ports:
         - containerPort: 8080
@@ -35,12 +35,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
+            cpu: 300m
+            memory: 200Mi
+          requests:
             cpu: 200m
             memory: 100Mi
-          requests:
-            cpu: 50m
-            memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1000

--- a/deploy/ingress.yaml
+++ b/deploy/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: kube-ops-view
+  namespace: default
 spec:
   rules:
   - host: "kube-ops-view.example.org"

--- a/deploy/redis-deployment.yaml
+++ b/deploy/redis-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     application: kube-ops-view-redis
     version: v0.0.1
   name: kube-ops-view-redis
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,9 +17,25 @@ spec:
         application: kube-ops-view-redis
         version: v0.0.1
     spec:
+      # Test
+      serviceAccountName: kube-ops-view-redis
+      # Since there are read-only filesystems, important data is copied to an
+      # emptyDir via an initContainer to avoid read-only errors
+      initContainers:
+      - name: copy-files-to-vol
+        image: bitnami/redis:5.0.5
+        command: ["sh", "-c", "[ \"$(ls -A /mnt/data)\" ] || (cp -R /opt/bitnami/redis/* /mnt/data/ && exit 0)"]
+        volumeMounts:
+        - name: bitnami-fs
+          mountPath: /mnt/data
       containers:
       - name: redis
-        image: redis:5-alpine
+        # bitnami/redis is chosen over library/redis so support out-of-the-box
+        # rootless containers
+        image: bitnami/redis:5.0.5
+        env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
         ports:
         - containerPort: 6379
           protocol: TCP
@@ -32,8 +49,16 @@ spec:
           requests:
             cpu: 50m
             memory: 50Mi
+        volumeMounts:
+        - mountPath: /bitnami/redis/data
+          name: redis-bitnami-data
+        - mountPath: /opt/bitnami/redis
+          name: bitnami-fs
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          # we need to use the "redis" uid
-          runAsUser: 100
+      volumes:
+      - name: redis-bitnami-data
+        emptyDir: {}
+      - name: bitnami-fs
+        emptyDir: {}

--- a/deploy/redis-service.yaml
+++ b/deploy/redis-service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     application: kube-ops-view-redis
   name: kube-ops-view-redis
+  namespace: default
 spec:
   selector:
     application: kube-ops-view-redis

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     application: kube-ops-view
   name: kube-ops-view
+  namespace: default
 spec:
   selector:
     application: kube-ops-view


### PR DESCRIPTION
I did the following to support running in secure/unprivileged environments (namely OpenShift)

- **Explicitly define the namespace for all objects**. In the event where one wants to change the namespace of the deployment, there needs to be a change to the ClusterRoleBinding of the kube-ops-view service account. This change makes it easier to understand and change the namespace of everything systematically.
- **Add a service account for the redis pod**. This is a bit more of an opinionated change, but I think explicitly defining a service account to consume allows more flexibility if permissions need to be changed at a later date.
- **Change serviceAccount to serviceAccountName in pod spec**. Kubernetes 1.15 docs use serviceAccountName (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account) so I'm updating this field to conform to that. I've noticed that when I deploy on OpenShift 3.11 using serviceAccountName instead of serviceAccount, the object actually created contains both fields and behaves as intended.
- **Update resource requests and limits for kube-ops-view deployment**. I frequently ran into issues with the kube-ops-view pod getting OOMKilled due to lack of resources in an environment with over 15 nodes. After bumping these resources, I no longer noticed any issues.
- **Removed uid 1000 from security context in kube-ops-view pod**. I removed this line and I don't see any error messages being thrown, so I think it's safe to remove.
- **Refactored redis deployment**. This is the big one for this commit. Running privileged containers is strongly discouraged in my environments, so I think I found a good solution to this. The container image is switched to bitnami/redis to support a rootless redis. Volumes are explicitly defined to support read-only containers. An init container is added to the bitnami image to support having the conf directory of the redis pod being read-write without mounting over its contents.

I'm looking for feedback and suggestions before this is merged. As I mentioned, I've tested this on OpenShift 3.11. This is a large PR, so if you need data from other Kubernetes environments (GKE, AKS) let me know I can test against those environments as well. Finally, if there is any specific data you need from these environments, let me know and I can get started on adding the data to the PR.