### PR TITLE
Add rule for crosscompiling arm image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ docker: appjs
 	docker build --build-arg "VERSION=$(VERSION)" -t "$(IMAGE):$(TAG)" .
 	@echo 'Docker image $(IMAGE):$(TAG) can now be used.'
 
+docker-arm: appjs
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx create --name arm-node --append --use --platform "linux/arm"
+	docker buildx build --build-arg "VERSION=$(VERSION)" --platform "linux/arm" -t $(IMAGE):$(TAG) --load .
+	@echo 'Docker image $(IMAGE):$(TAG) can now be used.'
+
 push: docker
 	docker push "$(IMAGE):$(TAG)"
 	docker tag "$(IMAGE):$(TAG)" "$(IMAGE):latest"


### PR DESCRIPTION
I am running a arm based cluster and it would be nice to get an "official" ARM build of kube-ops-view. I have already verified that everything works, and I am currently running [this image](https://cloud.docker.com/u/phillebaba/repository/docker/phillebaba/kube-ops-view) without any trouble in an ARM based cluster.

Cross compiling docker images has become a lot easier lately, so it does not require too many changes to cross compile for other architectures in the same CI flow.

This PR is more of a suggestion of how it could be done, as I am not aware of how the delivery of the image is done. It uses [qemu-user-static](https://github.com/multiarch/qemu-user-static) to run ARM images on x86 and [buildx](https://github.com/docker/buildx) to build the images with the correct metadata.

Currently the rule is setup to load the image into the local machine daemon when the build is complete. But it is also possible to set it up to build for multiple architectures and immediately push to docker hub.

Is there any interest adding ARM docker images to the build process?