### PR TITLE
Add ROUTE_PREFIX parameter for working with reverse proxies.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,8 @@ The following environment variables are supported:
     Template to make Nodes clickable, e.g. can point to `kube-web-view <https://codeberg.org/hjacobs/kube-web-view/>`_. ``{cluster}`` (cluster ID) and ``{name}`` (Node name) will be replaced in the URL template.
 ``POD_LINK_URL_TEMPLATE``
     Template to make Pods clickable, e.g. can point to `kube-web-view <https://codeberg.org/hjacobs/kube-web-view/>`_. ``{cluster}`` (cluster ID), ``{namespace}`` (Pod's namespace), and ``{name}`` (Pod name) will be replaced in the URL template.
-
+``ROUTE_PREFIX``
+    The URL prefix under which kube-ops-view is externally reachable (for example, if kube-ops-view is served via a reverse proxy). Used for generating relative and absolute links back to kube-ops-view itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by kube-ops-view. If omitted, relevant URL components will be derived automatically.
 
 Supported Browsers
 ==================

--- a/kube_ops_view/main.py
+++ b/kube_ops_view/main.py
@@ -97,6 +97,7 @@ def index():
         "index.html",
         app_js=app_js,
         version=kube_ops_view.__version__,
+        route_prefix=app.app_config["route_prefix"],
         app_config_json=json.dumps(app.app_config),
     )
 
@@ -229,6 +230,17 @@ class CommaSeparatedValues(click.ParamType):
     default=8080,
 )
 @click.option(
+    "--route-prefix",
+    help="""The URL prefix under which kube-ops-view is externally reachable
+    (for example, if kube-ops-view is served via a reverse proxy). Used for
+    generating relative and absolute links back to kube-ops-view itself. If the
+    URL has a path portion, it will be used to prefix all HTTP endpoints served
+    by kube-ops-view. If omitted, relevant URL components will be derived
+    automatically.""",
+    envvar="ROUTE_PREFIX",
+    default="/",
+)
+@click.option(
     "-d", "--debug", is_flag=True, help="Run in debugging mode", envvar="DEBUG"
 )
 @click.option(
@@ -287,6 +299,7 @@ class CommaSeparatedValues(click.ParamType):
     help="Template for target URL when clicking on a Pod",
     envvar="POD_LINK_URL_TEMPLATE",
 )
+
 def main(
     port,
     debug,
@@ -300,6 +313,7 @@ def main(
     query_interval,
     node_link_url_template: str,
     pod_link_url_template: str,
+    route_prefix: str,
 ):
     logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
 
@@ -311,6 +325,7 @@ def main(
     app.app_config = {
         "node_link_url_template": node_link_url_template,
         "pod_link_url_template": pod_link_url_template,
+        "route_prefix": route_prefix,
     }
 
     if mock:

--- a/kube_ops_view/templates/index.html
+++ b/kube_ops_view/templates/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Kubernetes Operational View {{ version }}</title>
-        <link rel="shortcut icon" href="static/favicon.ico">
+        <link rel="shortcut icon" href="{{ route_prefix }}static/favicon.ico">
 <style>* {padding: 0; margin: 0} body { color: #aaaaff; background: #000; }</style>
 <style>
 /* latin */
@@ -14,7 +14,7 @@
   font-weight: 400;
   /* ShareTechMono-Regular.ttf: Copyright (c) 2012, Carrois Type Design, Ralph du Carrois (www.carrois.com post@carrois.com), with Reserved Font Name 'Share'
      License: SIL Open Font License, 1.1 */
-  src: local('Share Tech Mono'), local('ShareTechMono-Regular'), url(static/sharetechmono.woff2) format('woff2');
+  src: local('Share Tech Mono'), local('ShareTechMono-Regular'), url({{ route_prefix }}static/sharetechmono.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 </style>
@@ -22,7 +22,7 @@
     <body>
         <!-- make sure the font is loaded -->
         <div id="loading" style="font-family: ShareTechMono">Loading..</div>
-        <script src="static/build/{{ app_js }}"></script>
+        <script src="{{ route_prefix }}static/build/{{ app_js }}"></script>
         <script>document.getElementById('loading').style.display = 'none'; const app = new App({{ app_config_json|safe }}); app.run()</script>
     </body>
 </html>

--- a/kube_ops_view/templates/screen-tokens.html
+++ b/kube_ops_view/templates/screen-tokens.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Screen Tokens</title>
-        <link rel="shortcut icon" href="static/favicon.ico">
+        <link rel="shortcut icon" href="{{ route_prefix }}static/favicon.ico">
     </head>
     <body>
         <h1>Screen Tokens</h1>


### PR DESCRIPTION
The `ROUTE_PREFIX` parameter can be useful for working with reverse proxies. 

In my case: I want to run kube-ops-view behind `nginx ingress` with defining path's. In current situation we have problem with loading assets, like scripts, fonts, etc.

My ingress configuration:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/backend-protocol: HTTP
    nginx.ingress.kubernetes.io/rewrite-target: /$1

...

  name: kube-ops-view
  namespace: kube-monitor
spec:
  rules:
  - host: dev-k8s-monitor.something.com
    http:
      paths:
      - backend:
          serviceName: kube-ops-view
          servicePort: 80
        path: /kube-ops-view/?(.*)
status:
  loadBalancer:
    ingress:
    - {}
```

When I open `dev-k8s-monitor.something.com/kube-ops-view` I see this: 

![Console](https://user-images.githubusercontent.com/13656104/72978486-fc718e80-3def-11ea-8fda-7152544d6e23.PNG)
![The HTML](https://user-images.githubusercontent.com/13656104/72978495-fed3e880-3def-11ea-8b93-2bc877da84a6.PNG)