### PR TITLE
Feature: Add cluster name in text field

### DIFF
--- a/app/src/cluster.js
+++ b/app/src/cluster.js
@@ -160,7 +160,7 @@ export default class Cluster extends PIXI.Graphics {
         topHandle.on('click', function(_event) {
             App.current.toggleCluster(that.cluster.id)
         })
-        const text = new PIXI.Text(this.cluster.api_server_url, {fontFamily: 'ShareTechMono', fontSize: 10, fill: 0x000000})
+        const text = new PIXI.Text("".concat(this.cluster.api_server_url, "(", this.cluster.id, ")"), {fontFamily: 'ShareTechMono', fontSize: 10, fill: 0x000000})
         text.x = 2
         text.y = 2
         topHandle.addChild(text)

--- a/app/src/cluster.js
+++ b/app/src/cluster.js
@@ -160,7 +160,7 @@ export default class Cluster extends PIXI.Graphics {
         topHandle.on('click', function(_event) {
             App.current.toggleCluster(that.cluster.id)
         })
-        const text = new PIXI.Text("".concat(this.cluster.api_server_url, "(", this.cluster.id, ")"), {fontFamily: 'ShareTechMono', fontSize: 10, fill: 0x000000})
+        const text = new PIXI.Text(''.concat(this.cluster.api_server_url, ' (', this.cluster.id, ')'), {fontFamily: 'ShareTechMono', fontSize: 10, fill: 0x000000})
         text.x = 2
         text.y = 2
         topHandle.addChild(text)


### PR DESCRIPTION
Recognition the cluster's name is very hard in multiple cluster env.
Because kube-ops-view shows only cluster's url.
So,  I added a new feature that shows cluster's name on cluster text field


This is what changed

Before:
![screenshot](https://user-images.githubusercontent.com/35264628/89730958-60069500-da7e-11ea-958b-53d1a03d01f0.png)

After:
![after](https://user-images.githubusercontent.com/35264628/89731221-3c444e80-da80-11ea-89c6-f91c7cf6ce56.png)

